### PR TITLE
Updated version constraint of Jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,9 @@ publishing {
 
 dependencies {
     compile 'org.apache.commons:commons-text:1.6'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.9.6'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.6'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
+    compile 'com.fasterxml.jackson.core:jackson-core:2.9.9'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.9'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.mockito:mockito-core:2.+"


### PR DESCRIPTION
- Updated version constraint of Jackson dependency

We like to use a streamlined Jackson version (2.9.9) in openHAB Core and all of its add-ons (see https://github.com/openhab/openhab-core/issues/892#issuecomment-520141490).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>